### PR TITLE
Make root-apps watch entire repo + add ArgoCD LoadBalancer service

### DIFF
--- a/bootstrap/root-app.yaml
+++ b/bootstrap/root-app.yaml
@@ -6,9 +6,11 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/mclaireh/argocd-apps-config.git  # YOUR repo URL here!
+    repoURL: https://github.com/mclaireh/argocd-apps-config.git
     targetRevision: HEAD
-    path: apps  # Points to the folder with child YAMLs
+    path: .
+    directory:
+      recurse: true
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd


### PR DESCRIPTION
This PR updates the root-apps Application to watch the entire repository (not just apps/) so that resources in infra/ (like Ingress, LoadBalancer services, and future platform components) are automatically discovered and managed.

Changes:

Modified bootstrap/root-app.yaml:
Changed path: apps → path: .
Added directory.recurse: true to recursively scan subfolders (apps/ + infra/)

Added infra/argocd-lb-service.yaml: New LoadBalancer Service (argocd-server-lb) for ArgoCD server pods, so MetalLB assigns a stable external IP.

Added infra/argocd-lb-app.yaml: ArgoCD Application to manage the LoadBalancer service declaratively.

Benefits:

Fixes the issue where infra/ files (e.g., argocd-lb-app, argocd-lb-service) weren't appearing in the UI.
Enables stable, port-free access via https://argocd.local network-wide (external-mDNS advertises the new LB IP).
Keeps everything fully GitOps — no manual kubectl patches or microk8s commands needed going forward.
Consistent pattern: infra/ for cluster plumbing, apps/ for workloads.