### PR TITLE
Add ArgoCD self-management via Helm chart

### DIFF
--- a/infra/argocd-app.yaml
+++ b/infra/argocd-app.yaml
@@ -1,0 +1,112 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argo-cd
+    targetRevision: 9.3.5
+    helm:
+      valuesObject:
+        configs:
+          cm:
+            resource.exclusions: |
+              - apiGroups:
+                - ''
+                - discovery.k8s.io
+                kinds:
+                - Endpoints
+                - EndpointSlice
+              - apiGroups:
+                - coordination.k8s.io
+                kinds:
+                - Lease
+              - apiGroups:
+                - authentication.k8s.io
+                - authorization.k8s.io
+                kinds:
+                - SelfSubjectReview
+                - TokenReview
+                - LocalSubjectAccessReview
+                - SelfSubjectAccessReview
+                - SelfSubjectRulesReview
+                - SubjectAccessReview
+              - apiGroups:
+                - certificates.k8s.io
+                kinds:
+                - CertificateSigningRequest
+              - apiGroups:
+                - cert-manager.io
+                kinds:
+                - CertificateRequest
+              - apiGroups:
+                - cilium.io
+                kinds:
+                - CiliumIdentity
+                - CiliumEndpoint
+                - CiliumEndpointSlice
+              - apiGroups:
+                - kyverno.io
+                - reports.kyverno.io
+                - wgpolicyk8s.io
+                kinds:
+                - PolicyReport
+                - ClusterPolicyReport
+                - EphemeralReport
+                - ClusterEphemeralReport
+                - AdmissionReport
+                - ClusterAdmissionReport
+                - BackgroundScanReport
+                - ClusterBackgroundScanReport
+                - UpdateRequest
+            resource.customizations.ignoreResourceUpdates.all: |
+              jsonPointers:
+                - /status
+            resource.customizations.ignoreResourceUpdates.ConfigMap: |
+              jqPathExpressions:
+                - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
+                - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
+            resource.customizations.ignoreResourceUpdates.Endpoints: |
+              jsonPointers:
+                - /metadata
+                - /subsets
+            resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
+              jqPathExpressions:
+                - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
+                - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
+                - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
+            resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
+              jqPathExpressions:
+                - '.metadata.annotations."notified.notifications.argoproj.io"'
+                - '.metadata.annotations."argocd.argoproj.io/refresh"'
+                - '.metadata.annotations."argocd.argoproj.io/hydrate"'
+                - '.operation'
+            resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
+              jqPathExpressions:
+                - '.metadata.annotations."notified.notifications.argoproj.io"'
+            resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
+              jqPathExpressions:
+                - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
+                - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
+                - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
+                - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
+            resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
+              jsonPointers:
+                - /metadata
+                - /endpoints
+                - /ports
+        server:
+          service:
+            type: ClusterIP
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

- Adds ArgoCD Application to manage ArgoCD itself using the official Helm chart
- Upgrades ArgoCD from v3.2.6 to latest (chart version 9.3.5)
- Migrates existing `argocd-cm` configuration to Helm values for GitOps management

## Changes

- New `infra/argocd-app.yaml` that deploys ArgoCD via Helm with:
  - Resource exclusions (Endpoints, Leases, auth resources, Cilium, Kyverno)
  - Ignore rules for noisy field updates (status, replica annotations, HPA)
  - Server service set to ClusterIP (external access via existing `argocd-server-lb`)

## Test Plan

- [ ] Verify ArgoCD pods restart and come back healthy
- [ ] Confirm UI is accessible after upgrade
- [ ] Check that existing Applications remain synced