### PR TITLE
Fix LoadBalancer targetPort to match ArgoCD server

### DIFF
--- a/infra/resources/argocd-lb-service.yaml
+++ b/infra/resources/argocd-lb-service.yaml
@@ -13,9 +13,9 @@ spec:
   ports:
     - name: https
       port: 443
-      targetPort: 443
+      targetPort: 8080
       protocol: TCP
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 8080
       protocol: TCP


### PR DESCRIPTION
## Summary

- Updates LoadBalancer service targetPort from 443/80 to 8080 to match the ArgoCD server container port

## Changes

- Changed `targetPort` for both HTTPS (443) and HTTP (80) to `8080`

## Why

The ArgoCD server listens on port 8080, not 443/80. The LoadBalancer should route external traffic (443/80) to the container's actual listening port (8080).

## Test Plan

- [ ] Verify ArgoCD UI is accessible at https://argocd.local