### PR TITLE
fixed typo

### DIFF
--- a/infra/resources/kustomization.yaml
+++ b/infra/resources/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 namespace: argocd
 
 resources:
-  - argocd-lb-app.yaml
+  - argocd-lb-service.yaml
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.2.6/manifests/install.yaml


### PR DESCRIPTION
## Summary

- Fixes incorrect resource filename in kustomization.yaml

## Changes

- Changed `argocd-lb-app.yaml` to `argocd-lb-service.yaml` in kustomization resources

## Why

The previous reference pointed to a non-existent file, causing the kustomization to fail.

## Test Plan

- [ ] Verify `kubectl apply -k` succeeds
- [ ] Confirm ArgoCD pods are running
- [ ] Verify UI is accessible at https://argocd.local