### PR TITLE
Add mDNS hostname annotation for ArgoCD LoadBalancer

### DIFF
--- a/infra/resources/argocd-lb-service.yaml
+++ b/infra/resources/argocd-lb-service.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: argocd.local
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
## Summary

- Adds external-dns annotation to advertise `argocd.local` via mDNS

## Changes

- Added `external-dns.alpha.kubernetes.io/hostname: argocd.local` annotation to `argocd-server-lb` service

## Why

The LoadBalancer service was missing the annotation that tells external-mdns to advertise the hostname. Without this, `argocd.local` doesn't resolve and requires direct IP access.

## Test Plan

- [ ] Verify external-mdns picks up the annotation
- [ ] Confirm `argocd.local` resolves to the LoadBalancer IP
- [ ] Access ArgoCD UI at https://argocd.local