### PR TITLE
Fixed a typo

### DIFF
--- a/infra/resources/argocd-cm-github-sso.yaml
+++ b/infra/resources/argocd-cm-github-sso.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: argocd
 data:
   # Argo CD base URL (must match how you reach the UI; used for OAuth callback)
-  url: https://argocd-server-lb.argocd.local/
+  url: https://argocd-server-lb.argocd.local
   dex.config: |
     connectors:
     - type: github


### PR DESCRIPTION
# Add GitHub SSO for Argo CD UI

## Summary

Enables **Login via GitHub** in the Argo CD UI using the bundled Dex IdP and a GitHub OAuth App. Only members of a configured GitHub organization can log in.

## What changed

### New files

- **`infra/resources/argocd-cm-github-sso.yaml`** – Patch for `argocd-cm`: sets `url` (Argo CD base URL, no trailing slash), and Dex GitHub connector with `clientID`, `clientSecret` (from `argocd-secret`), and `orgs` so only org members can complete login.
- **`infra/resources/GITHUB-SSO.md`** – Setup guide: create GitHub OAuth App, configure the patch (client ID + org), store client secret in `argocd-secret`, restart Dex, optional RBAC by org/team.
- **`infra/resources/argocd-rbac-cm-two-users.yaml`** – Optional RBAC patch for two users by email (no org); not applied by default.

### Modified

- **`infra/resources/kustomization.yaml`** – Applies `argocd-cm-github-sso.yaml` to the `argocd-cm` ConfigMap.
- **`README.md`** – Link and short steps for GitHub SSO (see GITHUB-SSO.md).

## Setup after merge

1. **GitHub OAuth App** (Developer settings → OAuth Apps → New OAuth App): set callback URL to `https://<argocd-base-url>/api/dex/callback`. Copy Client ID and generate a client secret.
2. **Patch** – In `argocd-cm-github-sso.yaml`, set `clientID` and `GITHUB_ORG`. Ensure `url` is your Argo CD base URL **with no trailing slash** (avoids 404 on `/api/dex`).
3. **Client secret in cluster** (never in Git):
   ```bash
   kubectl patch secret argocd-secret -n argocd --type merge \
     -p '{"stringData": {"dex.github.clientSecret": "<client-secret>"}}'
   ```
4. Sync the app that deploys `infra/resources`, then:
   ```bash
   kubectl rollout restart deployment argocd-dex-server -n argocd
   ```

Full steps: [infra/resources/GITHUB-SSO.md](infra/resources/GITHUB-SSO.md).

## Testing

- Argo CD login page shows **Login via GitHub**.
- GitHub user in the configured org can log in successfully.
- User not in the org is rejected by Dex.
