### PR TITLE
Add External Secrets Operator and Vault for secrets management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented in this file. Entries are gro
 
 ## 2026-02-04
 
+### **Add External Secrets Operator and Vault for secrets management**  
+**Branch:** `feature/secrets-management`  
+Adds Argo CD Applications for secrets tooling: `infra/eso-app.yaml` deploys External Secrets Operator (chart v1.3.2) into `external-secrets`; `infra/vault-app.yaml` deploys HashiCorp Vault (chart v0.32.0) into `vault`. Both use auto-sync, prune, and self-heal.
+
 ### **Add Gatekeeper via Helm**  
 **Branch:** `feature/gatekeeper`  
 Adds Argo CD Application (`infra/gatekeeper.yaml`) that deploys OPA Gatekeeper from the official Helm chart (v3.21.0) into `gatekeeper-system` with auto-sync, prune, and self-heal.

--- a/infra/eso-app.yaml
+++ b/infra/eso-app.yaml
@@ -1,0 +1,21 @@
+# infra/eso-app.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.external-secrets.io
+    chart: external-secrets
+    targetRevision: "1.3.2"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/vault-app.yaml
+++ b/infra/vault-app.yaml
@@ -1,0 +1,21 @@
+# infra/vault-app.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://helm.releases.hashicorp.com
+    chart: vault
+    targetRevision: "0.32.0"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vault
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

Adds Argo CD Applications for External Secrets Operator (ESO) and HashiCorp Vault so secrets can be managed via GitOps and synced from Vault (or other backends) into the cluster.

## Changes

- **`infra/eso-app.yaml`** — New Application that deploys [External Secrets Operator](https://external-secrets.io/) (Helm chart v1.3.2) into the `external-secrets` namespace. ESO syncs secrets from external stores (e.g. Vault, AWS Secrets Manager) into Kubernetes Secrets.
- **`infra/vault-app.yaml`** — New Application that deploys [HashiCorp Vault](https://www.vaultproject.io/) (Helm chart v0.32.0) into the `vault` namespace. Vault can act as the secrets backend for ESO or other workloads.
- **`CHANGELOG.md`** — Entry added for this addition (branch `feature/secrets-management`).

Both Applications use auto-sync, prune, self-heal, and `CreateNamespace=true`. The root app will pick them up from `infra/` and create the Applications.

## Notes

- After merge, configure ESO (e.g. `ClusterSecretStore` / `SecretStore`) to connect to Vault or another provider. Vault will need to be unsealed and configured separately.
