### PR TITLE
Fix External Secrets sync: use ServerSideApply for large CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented in this file. Entries are gro
 
 ## 2026-02-04
 
+### **Fix External Secrets sync: use ServerSideApply for large CRDs**  
+**Branch:** `feature/fix-eso-sync`  
+Fixes sync failures for the External Secrets application caused by CRD `metadata.annotations` exceeding Kubernetes’ 262144-byte limit. Adds `ServerSideApply=true` to `infra/eso-app.yaml` syncOptions so Argo CD uses server-side apply and no longer stores the full resource in annotations.
+
 ### **Add External Secrets Operator and Vault for secrets management**  
 **Branch:** `feature/secrets-management`  
 Adds Argo CD Applications for secrets tooling: `infra/eso-app.yaml` deploys External Secrets Operator (chart v1.3.2) into `external-secrets`; `infra/vault-app.yaml` deploys HashiCorp Vault (chart v0.32.0) into `vault`. Both use auto-sync, prune, and self-heal.

--- a/infra/eso-app.yaml
+++ b/infra/eso-app.yaml
@@ -19,3 +19,6 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # Avoid CRD annotation size limit (262144 bytes): use server-side apply
+      # so Argo CD does not store full resource in last-applied-configuration.
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

Fixes sync failures for the External Secrets application caused by Kubernetes’ annotation size limit on the CRDs.

## Problem

Sync was failing with:

```
CustomResourceDefinition "clustersecretstores.external-secrets.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
CustomResourceDefinition "secretstores.external-secrets.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
```

Argo CD’s default client-side apply stores the full resource in the `kubectl.kubernetes.io/last-applied-configuration` annotation. The ESO CRDs are large enough that this annotation exceeds the 262144-byte limit, so the API server rejects the apply.

## Solution

Add `ServerSideApply=true` to the External Secrets Application’s `syncOptions`. Server-side apply does not use that annotation, so the limit is no longer hit and the CRDs apply successfully.

## Changes

- **`infra/eso-app.yaml`** — Under `syncPolicy.syncOptions`, added `ServerSideApply=true` and a short comment explaining why.

## References

- [Argo CD Server-Side Apply](https://argo-cd.readthedocs.io/en/stable/user-guide/server-side-apply/)
- Similar issue: argoproj/argo-cd#11269 (large CRD annotations)