### PR TITLE
Gatekeeper: set webhook timeout, controller resources, and audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented in this file. Entries are gro
 
 ## 2026-02-04
 
+### **Gatekeeper: add Helm values for webhook, resources, and audit**  
+**Branch:** `fix/gatekeeper`  
+Configures the Gatekeeper Application with Helm values: `validatingWebhookTimeoutSeconds: 3`, controller manager resource limits/requests (cpu/memory), and audit enabled with 60s interval.
+
 ### **Fix External Secrets sync: use ServerSideApply for large CRDs**  
 **Branch:** `feature/fix-eso-sync`  
 Fixes sync failures for the External Secrets application caused by CRD `metadata.annotations` exceeding Kubernetes’ 262144-byte limit. Adds `ServerSideApply=true` to `infra/eso-app.yaml` syncOptions so Argo CD uses server-side apply and no longer stores the full resource in annotations.

--- a/infra/gatekeeper.yaml
+++ b/infra/gatekeeper.yaml
@@ -1,3 +1,4 @@
+# infra/gatekeeper.yaml (complete version)
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -9,6 +10,20 @@ spec:
     repoURL: https://open-policy-agent.github.io/gatekeeper/charts
     chart: gatekeeper
     targetRevision: 3.21.0
+    helm:
+      values: |
+        validatingWebhookTimeoutSeconds: 3
+        controllerManager:
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        audit:
+          enabled: true
+          interval: 60
   destination:
     server: https://kubernetes.default.svc
     namespace: gatekeeper-system


### PR DESCRIPTION
## Summary

Configures the Gatekeeper Argo CD Application with Helm values for webhook timeout, controller resource limits/requests, and audit.

## Changes

- **`infra/gatekeeper.yaml`**
  - **validatingWebhookTimeoutSeconds: 3** — Shorter timeout for the validating webhook.
  - **controllerManager.resources** — Limits (cpu: 500m, memory: 512Mi) and requests (cpu: 100m, memory: 128Mi) for the Gatekeeper controller.
  - **audit** — Audit enabled with **interval: 60** (seconds) for periodic constraint evaluation.

## Why

- Avoids webhook timeouts and gives the controller predictable resource usage.
- Audit runs every 60s to report constraint violations (e.g. required-labels) for resources that were not created through the admission webhook.
